### PR TITLE
Add experimental additional source for data provided via stdin

### DIFF
--- a/src/main/scala/com/herminiogarcia/shexml/helper/SourceHelper.scala
+++ b/src/main/scala/com/herminiogarcia/shexml/helper/SourceHelper.scala
@@ -23,7 +23,9 @@ class SourceHelper {
   def getContentFromRelativePath(path: String): LoadedSource = searchFileResult(path) match {
     case Some(result) => result
     case None =>
-      val file = scala.io.Source.fromFile(path, "UTF-8")
+      val file = if (path.equals("-"))
+        scala.io.Source.fromInputStream(System.in, "UTF-8")
+      else scala.io.Source.fromFile(path, "UTF-8")
       try {
         val content = LoadedSource(file.mkString, path)
         saveFileResult(path, content)

--- a/src/main/scala/com/herminiogarcia/shexml/visitor/RDFGeneratorVisitor.scala
+++ b/src/main/scala/com/herminiogarcia/shexml/visitor/RDFGeneratorVisitor.scala
@@ -1,6 +1,5 @@
 package com.herminiogarcia.shexml.visitor
 
-import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import com.herminiogarcia.shexml.ast.{AST, Action, ActionOrLiteral, AutoIncrement, CSVPerRow, DataTypeGeneration, DataTypeLiteral, Declaration, Exp, FieldQuery, FunctionCalling, Graph, IRI, IteratorQuery, JdbcURL, Join, JsonPath, LangTagGeneration, LangTagLiteral, LiteralObject, LiteralObjectValue, LiteralSubject, Matcher, Matchers, ObjectElement, Predicate, PredicateObject, Prefix, QueryClause, RDFAlt, RDFBag, RDFCollection, RDFList, RDFSeq, RelativePath, ShExML, Shape, ShapeLink, ShapeVar, Sparql, SparqlColumn, Sql, SqlColumn, StringOperation, Substitution, URL, Union, Var, VarResult, Variable, XmlPath}
 import com.herminiogarcia.shexml.helper.{FunctionHubExecuter, LoadedSource, SourceHelper}
@@ -50,6 +49,10 @@ class RDFGeneratorVisitor(dataset: Dataset, varTable: mutable.HashMap[Variable, 
   protected val xmlDocumentCache = new XMLDocumentCache()
   protected val functionHubExecuterCache = new FunctionHubExecuterCache()
   protected val defaultModel = dataset.getDefaultModel
+  protected val jsonPathConfiguration = Configuration.defaultConfiguration()
+    .addOptions(com.jayway.jsonpath.Option.ALWAYS_RETURN_LIST)
+    .addOptions(com.jayway.jsonpath.Option.DEFAULT_PATH_LEAF_TO_NULL)
+    .addOptions(com.jayway.jsonpath.Option.SUPPRESS_EXCEPTIONS)
 
   private val xmlProcessor = new Processor(false)
 
@@ -437,11 +440,7 @@ class RDFGeneratorVisitor(dataset: Dataset, varTable: mutable.HashMap[Variable, 
               logger.debug(s"Retrieving cached result for already parsed JSON file")
               jsonNode
             case None =>
-              val configuration = Configuration.defaultConfiguration()
-                .addOptions(com.jayway.jsonpath.Option.ALWAYS_RETURN_LIST)
-                .addOptions(com.jayway.jsonpath.Option.DEFAULT_PATH_LEAF_TO_NULL)
-                .addOptions(com.jayway.jsonpath.Option.SUPPRESS_EXCEPTIONS)
-              val context = com.jayway.jsonpath.JsonPath.using(configuration).parse(file.fileContent)
+              val context = com.jayway.jsonpath.JsonPath.using(jsonPathConfiguration).parse(file.fileContent)
               jsonObjectMapperCache.save(file, context)
               context
           }

--- a/src/test/scala/com/herminiogarcia/shexml/FilmsStdin.scala
+++ b/src/test/scala/com/herminiogarcia/shexml/FilmsStdin.scala
@@ -1,0 +1,82 @@
+package com.herminiogarcia.shexml
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.jena.datatypes.xsd.XSDDatatype
+import org.scalactic.source.Position
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers
+
+import scala.io.Source
+
+class FilmsStdin extends AnyFunSuite with Matchers with RDFStatementCreator with BeforeAndAfter {
+
+  override def after(fun: => Any)(implicit pos: Position): Unit = try System.setIn(System.in) finally super.after(fun)
+
+  private val example =
+    """
+      PREFIX : <http://example.com/>
+      |SOURCE films_xml_file <./src/test/resources/filmsAlt.xml>
+      |SOURCE films_json_file <->
+      |ITERATOR film_xml <xpath: //film> {
+      |    FIELD name <name>
+      |    FIELD year <year>
+      |    FIELD country <country>
+      |    FIELD directors <directors/director>
+      |    FIELD comment <comment>
+      |}
+      |ITERATOR film_json <jsonpath: $.films[*]> {
+      |    FIELD name <['name of the film']>
+      |    FIELD year <year>
+      |    FIELD country <country>
+      |    FIELD directors <director>
+      |    FIELD comment <comment>
+      |}
+      |EXPRESSION films <films_xml_file.film_xml UNION films_json_file.film_json>
+      |
+      |:Films :film1 {
+      |    a :Film ;
+      |    :name [films.name] ;
+      |    :year [films.year] ;
+      |    :country [films.country] ;
+      |    :director [films.directors] ;
+      |    :comment [films.comment] ;
+      |}
+    """.stripMargin
+
+  private val prefix = "http://example.com/"
+  val data = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("filmsAlt.json")).mkString
+  val node = new ObjectMapper().readTree(data)
+
+  private val mappingLauncher = new MappingLauncher(inferenceDatatype = true, normaliseURIs = true)
+  private val output = mappingLauncher.launchMappingFromJsonData(example, node).getDefaultModel
+
+
+  test("Shape film1 contains all the data, literal action, enhancement-#97") {
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "name", "Dunkirk", XSDDatatype.XSDstring)))
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "year", "2017", XSDDatatype.XSDinteger)))
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "country", "USA", XSDDatatype.XSDstring)))
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "director", "Christopher Nolan", XSDDatatype.XSDstring)))
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "year", "2010", XSDDatatype.XSDinteger)))
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "country", "USA", XSDDatatype.XSDstring)))
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "director", "Christopher Nolan", XSDDatatype.XSDstring)))
+  }
+
+  test("Allow spaces in the JSONPath expression, bug-#98") {
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "name", "Inception", XSDDatatype.XSDstring)))
+  }
+
+  test("Escape quote marks inside strings, enhancement-#99") {
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "comment", "A \"different\" movie", XSDDatatype.XSDstring)))
+  }
+
+  test("Avoid URL generation when string does not start by it, bug-#100") {
+    assert(output.contains(createStatementWithLiteral(prefix, "film1", "comment", "Very interesting movie, see more comments on: http://example.com/comments", XSDDatatype.XSDstring)))
+  }
+
+  test("No additional triples are generated") {
+    val triplesCount = 9
+    assert(output.size() == triplesCount)
+  }
+
+}


### PR DESCRIPTION
As per unix custom, using '-' as the source prompts the mapper to read the data from stdin. To illustrate one use for this I've also added a new method on the launcher `launchMappingFromJsonData` which runs the mapping on a provided JsonNode object. Behind the scenes this using the stdin input, which is a bit of a hack tbh.

A practical use for this is pushing data into the mapper, rather than letting it fetch data from sources, which is something you might want to do in a streaming context.

**I'm not going to pretend this is the optimal implementation however!**